### PR TITLE
Update HTML_Common for PHP7.4+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+name: PHP Code Quality
+on:
+  pull_request:
+    branches:
+      - trunk
+  push:
+    branches:
+      - trunk
+
+jobs:
+  quality:
+    name: Code Quality PHP (${{matrix.php_versions}})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php_versions: ['7.4', '8.0', '8.1', '8.2']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP ${{ matrix.php_versions}}
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: ${{matrix.php_versions}}
+          tools: composer, cs2pr, parallel-lint, phpcs, phpstan, psalm
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v3
+        name: Cache Composer Dependencies
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Linting
+        run: |
+          parallel-lint --no-colors --no-progress --checkstyle ./Common.php | cs2pr
+      - name: Run Static Analysis (PHPStan)
+        run: phpstan analyse

--- a/Common.php
+++ b/Common.php
@@ -139,7 +139,7 @@ abstract class HTML_Common
         $strAttr = '';
 
         if (is_array($attributes)) {
-            $charset = $this->charset();
+            $charset = self::charset();
             foreach ($attributes as $key => $value) {
                 $strAttr .= ' ' . $key . '="' . htmlspecialchars($value, ENT_COMPAT, $charset) . '"';
             }
@@ -450,7 +450,7 @@ abstract class HTML_Common
      * @access  public
      * @static
      */
-    public function charset(?string $newCharset = null)
+    public static function charset(?string $newCharset = null)
     {
         static $charset = 'ISO-8859-1';
 

--- a/Common.php
+++ b/Common.php
@@ -30,21 +30,21 @@
  * @version     Release: @package_version@
  * @abstract
  */
-class HTML_Common
+abstract class HTML_Common
 {
     /**
      * Associative array of attributes
      * @var     array
      * @access  private
      */
-    var $_attributes = array();
+    private $_attributes = [];
 
     /**
      * Tab offset of the tag
      * @var     int
      * @access  private
      */
-    var $_tabOffset = 0;
+    private $_tabOffset = 0;
 
     /**
      * Tab string
@@ -52,7 +52,7 @@ class HTML_Common
      * @since     1.7
      * @access    private
      */
-    var $_tab = "\11";
+    private $_tab = "\11";
 
     /**
      * Contains the line end string
@@ -60,7 +60,7 @@ class HTML_Common
      * @since     1.7
      * @access    private
      */
-    var $_lineEnd = "\12";
+    private $_lineEnd = "\12";
 
     /**
      * HTML comment on the object
@@ -68,7 +68,7 @@ class HTML_Common
      * @since     1.5
      * @access    private
      */
-    var $_comment = '';
+    private $_comment = '';
 
     /**
      * Class constructor
@@ -77,7 +77,7 @@ class HTML_Common
      * @param    int     $tabOffset      Indent offset in tabs
      * @access   public
      */
-    function HTML_Common($attributes = null, $tabOffset = 0)
+    public function __construct($attributes = null, int $tabOffset = 0)
     {
         $this->setAttributes($attributes);
         $this->setTabOffset($tabOffset);
@@ -88,7 +88,7 @@ class HTML_Common
      * @access   public
      * @returns  double
      */
-    function apiVersion()
+    public function apiVersion(): float
     {
         return 1.7;
     } // end func apiVersion
@@ -100,7 +100,7 @@ class HTML_Common
      * @access    private
      * @return    string
      */
-    function _getLineEnd()
+    protected function _getLineEnd()
     {
         return $this->_lineEnd;
     } // end func getLineEnd
@@ -112,7 +112,7 @@ class HTML_Common
      * @access    private
      * @return    string
      */
-    function _getTab()
+    protected function _getTab()
     {
         return $this->_tab;
     } // end func _getTab
@@ -123,7 +123,7 @@ class HTML_Common
      * @return    string
      * @access   private
      */
-    function _getTabs()
+    protected function _getTabs()
     {
         return str_repeat($this->_getTab(), $this->_tabOffset);
     } // end func _getTabs
@@ -134,12 +134,12 @@ class HTML_Common
      * @return   string
      * @access   private
      */
-    function _getAttrString($attributes)
+    protected function _getAttrString(array $attributes)
     {
         $strAttr = '';
 
         if (is_array($attributes)) {
-            $charset = HTML_Common::charset();
+            $charset = $this->charset();
             foreach ($attributes as $key => $value) {
                 $strAttr .= ' ' . $key . '="' . htmlspecialchars($value, ENT_COMPAT, $charset) . '"';
             }
@@ -153,7 +153,7 @@ class HTML_Common
      * @access   private
      * @return   array
      */
-    function _parseAttributes($attributes)
+    protected function _parseAttributes($attributes)
     {
         if (is_array($attributes)) {
             $ret = array();
@@ -167,7 +167,7 @@ class HTML_Common
             }
             return $ret;
 
-        } elseif (is_string($attributes)) {
+        } else if (is_string($attributes)) {
             $preg = "/(([A-Za-z_:]|[^\\x00-\\x7F])([A-Za-z0-9_:.-]|[^\\x00-\\x7F])*)" .
                 "([ \\n\\t\\r]+)?(=([ \\n\\t\\r]+)?(\"[^\"]*\"|'[^']*'|[^ \\n\\t\\r]*))?/";
             if (preg_match_all($preg, $attributes, $regs)) {
@@ -188,6 +188,7 @@ class HTML_Common
                 return $arrAttr;
             }
         }
+        return [];
     } // end func _parseAttributes
 
     /**
@@ -199,7 +200,7 @@ class HTML_Common
      * @access    private
      * @return    bool
      */
-    function _getAttrKey($attr, $attributes)
+    protected function _getAttrKey(string $attr, array $attributes)
     {
         if (isset($attributes[strtolower($attr)])) {
             return true;
@@ -214,7 +215,7 @@ class HTML_Common
      * @param    array   $attr2      New attributes array
      * @access   private
      */
-    function _updateAttrArray(&$attr1, $attr2)
+    protected function _updateAttrArray(array &$attr1, array $attr2)
     {
         if (!is_array($attr2)) {
             return false;
@@ -233,7 +234,7 @@ class HTML_Common
      * @access    private
      * @return    void
      */
-    function _removeAttr($attr, &$attributes)
+    protected function _removeAttr(string $attr, array &$attributes)
     {
         $attr = strtolower($attr);
         if (isset($attributes[$attr])) {
@@ -249,7 +250,7 @@ class HTML_Common
      * @access    public
      * @return    string|null   returns null if an attribute does not exist
      */
-    function getAttribute($attr)
+    public function getAttribute(string $attr)
     {
         $attr = strtolower($attr);
         if (isset($this->_attributes[$attr])) {
@@ -265,7 +266,7 @@ class HTML_Common
      * @param   string  Attribute value (will be set to $name if omitted)
      * @access  public
      */
-    function setAttribute($name, $value = null)
+    public function setAttribute(string $name, ?string $value = null)
     {
         $name = strtolower($name);
         if (is_null($value)) {
@@ -279,7 +280,7 @@ class HTML_Common
      * @param    mixed   $attributes     Either a typical HTML attribute string or an associative array
      * @access   public
      */
-    function setAttributes($attributes)
+    public function setAttributes($attributes)
     {
         $this->_attributes = $this->_parseAttributes($attributes);
     } // end func setAttributes
@@ -292,7 +293,7 @@ class HTML_Common
      * @access    public
      * @return    mixed   attributes
      */
-    function getAttributes($asString = false)
+    public function getAttributes(bool $asString = false)
     {
         if ($asString) {
             return $this->_getAttrString($this->_attributes);
@@ -306,7 +307,7 @@ class HTML_Common
      * @param    mixed   $attributes     Either a typical HTML attribute string or an associative array
      * @access   public
      */
-    function updateAttributes($attributes)
+    public function updateAttributes($attributes)
     {
         $this->_updateAttrArray($this->_attributes, $this->_parseAttributes($attributes));
     } // end func updateAttributes
@@ -319,7 +320,7 @@ class HTML_Common
      * @access    public
      * @return    void
      */
-    function removeAttribute($attr)
+    public function removeAttribute($attr)
     {
         $this->_removeAttr($attr, $this->_attributes);
     } //end func removeAttribute
@@ -332,7 +333,7 @@ class HTML_Common
      * @access  public
      * @return  void
      */
-    function setLineEnd($style)
+    public function setLineEnd(string $style)
     {
         switch ($style) {
             case 'win':
@@ -355,7 +356,7 @@ class HTML_Common
      * @param    int     $offset
      * @access   public
      */
-    function setTabOffset($offset)
+    public function setTabOffset(int $offset)
     {
         $this->_tabOffset = $offset;
     } // end func setTabOffset
@@ -367,7 +368,7 @@ class HTML_Common
      * @access    public
      * @return    int
      */
-    function getTabOffset()
+    public function getTabOffset()
     {
         return $this->_tabOffset;
     } //end func getTabOffset
@@ -380,7 +381,7 @@ class HTML_Common
      * @access    public
      * @return    void
      */
-    function setTab($string)
+    public function setTab(string $string)
     {
         $this->_tab = $string;
     } // end func setTab
@@ -393,7 +394,7 @@ class HTML_Common
      * @access    public
      * @return    void
      */
-    function setComment($comment)
+    public function setComment(string $comment)
     {
         $this->_comment = $comment;
     } // end func setHtmlComment
@@ -405,7 +406,7 @@ class HTML_Common
      * @access    public
      * @return    string
      */
-    function getComment()
+    public function getComment()
     {
         return $this->_comment;
     } //end func getComment
@@ -417,17 +418,14 @@ class HTML_Common
      * @return    string
      * @abstract
      */
-    function toHtml()
-    {
-        return '';
-    } // end func toHtml
+    abstract public function toHtml(): string;
 
     /**
      * Displays the HTML to the screen
      *
      * @access    public
      */
-    function display()
+    public function display()
     {
         print $this->toHtml();
     } // end func display
@@ -452,7 +450,7 @@ class HTML_Common
      * @access  public
      * @static
      */
-    function charset($newCharset = null)
+    public function charset(?string $newCharset = null)
     {
         static $charset = 'ISO-8859-1';
 

--- a/Common.php
+++ b/Common.php
@@ -37,14 +37,14 @@ abstract class HTML_Common
      * @var     array
      * @access  private
      */
-    private $_attributes = [];
+    protected $_attributes = [];
 
     /**
      * Tab offset of the tag
      * @var     int
      * @access  private
      */
-    private $_tabOffset = 0;
+    protected $_tabOffset = 0;
 
     /**
      * Tab string
@@ -52,7 +52,7 @@ abstract class HTML_Common
      * @since     1.7
      * @access    private
      */
-    private $_tab = "\11";
+    protected $_tab = "\11";
 
     /**
      * Contains the line end string
@@ -60,7 +60,7 @@ abstract class HTML_Common
      * @since     1.7
      * @access    private
      */
-    private $_lineEnd = "\12";
+    protected $_lineEnd = "\12";
 
     /**
      * HTML comment on the object
@@ -68,7 +68,7 @@ abstract class HTML_Common
      * @since     1.5
      * @access    private
      */
-    private $_comment = '';
+    protected $_comment = '';
 
     /**
      * Class constructor

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
     },
     "type": "library",
     "require": {
-        "pear/pear_exception": "*"
+        "php": ">=7.4",
+        "pear/pear_exception": "*",
+        "phpstan/phpstan": "^1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
     "type": "library",
     "require": {
         "php": ">=7.4",
-        "pear/pear_exception": "*",
-        "phpstan/phpstan": "^1.7"
+        "pear/pear_exception": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "*",
+        "phpstan/phpstan": "^1.7"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 0
+    paths:
+        - ./
+    parallel:
+        maximumNumberOfProcesses: 2
+    excludePaths:
+        - ./vendor
+    reportMaybesInMethodSignatures: true
+    reportStaticMethodSignatures: true
+    checkExplicitMixedMissingReturn: true
+    checkInternalClassCaseSensitivity: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    phpVersion: 80000

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,4 +11,3 @@ parameters:
     checkExplicitMixedMissingReturn: true
     checkInternalClassCaseSensitivity: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
-    phpVersion: 80000

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,13 +1,4 @@
 parameters:
     level: 0
     paths:
-        - ./
-    parallel:
-        maximumNumberOfProcesses: 2
-    excludePaths:
-        - ./vendor
-    reportMaybesInMethodSignatures: true
-    reportStaticMethodSignatures: true
-    checkExplicitMixedMissingReturn: true
-    checkInternalClassCaseSensitivity: true
-    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+        - ./Common.php


### PR DESCRIPTION
With the coming of PHP8.0, many legacy codebases "broke", for the newest major version contains a lot of changes which are incompatible with older code.

This pull request, contains several changes to modernize the HTML_Common class, of which one is of the greatest importance: the renaming of the class's constructor.

Furthermore a simple workflow was added with linting and basic static analysis, to ensure that the changes work and to facilitate future refactorings. 